### PR TITLE
feat: allow more than one argument in intercom instance

### DIFF
--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -76,7 +76,7 @@ const loadScript = (settings: IntercomSettings): Promise<typeof Intercom> => {
 
 export async function getIntercomInstance(
   command?: Intercom_.IntercomCommand,
-  args?: any
+  ...args: any
 ): Promise<typeof Intercom | void> {
   let instance = window.Intercom as any;
 
@@ -88,7 +88,7 @@ export async function getIntercomInstance(
     instance = await loadScript(INTERCOM_SETTINGS);
   }
 
-  return command ? instance(command, args) : instance;
+  return command ? instance(command, ...args) : instance;
 }
 
 const intercomPlugin: Plugin = (ctx, inject): void => {


### PR DESCRIPTION
Hey, first of all, thanks for the module. I'm opening up this PR, because in a situation where we need to use the `trackEvent` command we might need extra parameters. So the right approach would be to use the spread operator on the `args` parameter.

Example of usage:
```
const metadata = {
  invitee_email: 'pi@example.org',
  invite_code: 'ADDAFRIEND'
};
$intercom('trackEvent', 'invited-friend', metadata);
```