### PR TITLE
chore: intercom-web types updated into the 2.8.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "nuxt-intercom",
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@types/intercom-web": "^2.8.15"
+        "@types/intercom-web": "^2.8.18"
       },
       "devDependencies": {
         "@nuxt/types": "^2.15.8",
@@ -2478,6 +2477,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3141,9 +3143,9 @@
       "dev": true
     },
     "node_modules/@types/intercom-web": {
-      "version": "2.8.15",
-      "resolved": "https://registry.npmjs.org/@types/intercom-web/-/intercom-web-2.8.15.tgz",
-      "integrity": "sha512-+lKBGQn0tWLBI0ELMTa+QDI+5dAq/s4z2e7k8ddYhcXdb8vVKxbgvfcs0ND+S7wWR05V7NRBUxZM9PSKRSLNgQ=="
+      "version": "2.8.18",
+      "resolved": "https://registry.npmjs.org/@types/intercom-web/-/intercom-web-2.8.18.tgz",
+      "integrity": "sha512-BmXa2A1cKNA5zhWYIWOvKT1Hv9E+IbMdAuCi80Qez+s2IDh8YuzMvIpawLr65gOhW5bxL/AjbFm954o/Fm0QmA=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
@@ -3480,6 +3482,7 @@
         "merge-source-map": "^1.1.0",
         "postcss": "^7.0.36",
         "postcss-selector-parser": "^6.0.2",
+        "prettier": "^1.18.2 || ^2.0.0",
         "source-map": "~0.6.1",
         "vue-template-es2015-compiler": "^1.9.0"
       },
@@ -4794,6 +4797,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -8354,6 +8358,7 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -13911,8 +13916,10 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.1"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -13996,6 +14003,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -17587,9 +17595,9 @@
       "dev": true
     },
     "@types/intercom-web": {
-      "version": "2.8.15",
-      "resolved": "https://registry.npmjs.org/@types/intercom-web/-/intercom-web-2.8.15.tgz",
-      "integrity": "sha512-+lKBGQn0tWLBI0ELMTa+QDI+5dAq/s4z2e7k8ddYhcXdb8vVKxbgvfcs0ND+S7wWR05V7NRBUxZM9PSKRSLNgQ=="
+      "version": "2.8.18",
+      "resolved": "https://registry.npmjs.org/@types/intercom-web/-/intercom-web-2.8.18.tgz",
+      "integrity": "sha512-BmXa2A1cKNA5zhWYIWOvKT1Hv9E+IbMdAuCi80Qez+s2IDh8YuzMvIpawLr65gOhW5bxL/AjbFm954o/Fm0QmA=="
     },
     "@types/json-schema": {
       "version": "7.0.9",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "npm run clean && npm run transpile"
   },
   "dependencies": {
-    "@types/intercom-web": "^2.8.15"
+    "@types/intercom-web": "^2.8.18"
   },
   "devDependencies": {
     "@nuxt/types": "^2.15.8",


### PR DESCRIPTION
Hi. First of all thanks for this great package which works very smoothly and helps me daily basis.

After version, `2.8.18` of [@types/intercom-web](https://www.npmjs.com/package/@types/intercom-web), `showArticle` method was added to the types and since the `$intercom` instance of your package dependent on this package, it is not possible to use `showArticle` method in a natural type-safe way.

Example:

```ts
// Usage right now (Otherwise you'll get 'Argument of type '"showArticle"' is not assignable to parameter of type 'keyof IntercomCommandSignature | undefined'.)

this.$intercom('showArticle' as keyof Intercom_.IntercomCommandSignature, 12345678)

// Usage after
this.$intercom('showArticle', 12345678)
````
